### PR TITLE
Add extracting translateable strings

### DIFF
--- a/scripts/commons/serviceportal/forms/ConsistentTranslationValidator.groovy
+++ b/scripts/commons/serviceportal/forms/ConsistentTranslationValidator.groovy
@@ -138,12 +138,30 @@ class ConsistentTranslationValidator {
    */
   private static boolean isTranslatableAttribute(String attributePath) {
     if (attributePath == "id") return true // The id of the form has to be different, as they are separate forms
+
     if (attributePath.endsWith("title")) return true // title of sections or similar
     if (attributePath.endsWith("label")) return true // labels of questions
+    if (attributePath.endsWith("placeholder")) return true // placeholder in questions
+
     if (attributePath.endsWith("additionalConfig.text")) return true // E.g. the label of hint-boxes
+
+    if (attributePath.endsWith("caption")) return true // image caption
+    if (attributePath.endsWith("alt")) return true // image alt tag
+
     if (attributePath.endsWith("helptext")) return true // Hover text on labels
     if (attributePath.endsWith("addRowButton")) return true // Button labels
     if (attributePath.endsWith("deleteRowButton")) return true // Button labels
+    if (attributePath.endsWith("addRowButtonInfoText")) return true // hover text for AddRow buttons
+    if (attributePath.endsWith("deleteRowButtonInfoText")) return true // hover text for DeleteRow buttons
+
+    if (attributePath.endsWith("instanceTitleTemplate")) return true // template for repeatable groups / accordions
+
+    if (attributePath.endsWith("requiredValidationFailedMessage")) return true // message if validation failed
+    if (attributePath.endsWith("typeValidationFailedMessage")) return true // message if validation failed
+    if (attributePath.endsWith("validationErrorMessage")) return true // message if validation failed
+    if (attributePath.endsWith("validationInvalidNumberMessage")) return true // message if validation failed
+    if (attributePath.endsWith("validationDecimalPointError")) return true // message if validation failed
+    if (attributePath.endsWith("validationNonNegativeNumberError")) return true // message if validation failed
 
     return false
   }

--- a/scripts/commons/serviceportal/forms/ConsistentTranslationValidator.groovy
+++ b/scripts/commons/serviceportal/forms/ConsistentTranslationValidator.groovy
@@ -53,11 +53,7 @@ class ConsistentTranslationValidator {
     List<Difference> differences = findDifferences(form1, form2)
 
     // Remove acceptable differences
-    differences.removeAll { it.path == "id" } // The id of the form has to be different, as they are separate forms
-    differences.removeAll { it.path.endsWith("title") } // The title attribute is only used for display purposes
-    differences.removeAll { it.path.endsWith("label") } // The label attribute is only used for display purposes
-    differences.removeAll { it.path.endsWith("additionalConfig.text") } // The text attribute (of the additionalConfig element) is only used for display purposes
-    differences.removeAll { it.path.endsWith("helptext") } // The helptext is only used for display purposes
+    differences.removeAll { isTranslatableAttribute(it.path) }
 
     // Check if there are any non-acceptable differences remaining
     if (differences.isEmpty()) {
@@ -97,7 +93,27 @@ class ConsistentTranslationValidator {
     return differences.findAll { it != null }
   }
 
+  /**
+   * Returns if a give attribute (from the form json) is allowed to be translated.
+   *
+   * Examples:
+   * - The root "id" attribute --> true, because a translated form will have a different id
+   * - Attributes, ending in "label" --> true, because that's the text a user reads in front of a form field
+   * - The "id" attribute of a field --> false, because that might be used in a display condition
+   *
+   * @param attributePath the json path to the attribute. E.g. "sections[0].fieldGroups[1].rows[3].fields[0].label"
+   *
+   * @return true or false
+   */
+  private static boolean isTranslatableAttribute(String attributePath) {
+    if (attributePath == "id" ) return true // The id of the form has to be different, as they are separate forms
+    if (attributePath.endsWith("title")) return true // The title attribute is only used for display purposes
+    if (attributePath.endsWith("label")) return true // The label attribute is only used for display purposes
+    if (attributePath.endsWith("additionalConfig.text")) return true // The text attribute (of the additionalConfig element) is only used for display purposes
+    if (attributePath.endsWith("helptext")) return true // The helptext is only used for display purposes
 
+    return false
+  }
 }
 
 class Difference {


### PR DESCRIPTION
Hier ein PR mit dem eine Methode hinzugefügt wird, die "übersetzbare" String in einem Formular sucht und ausgibt. Das kann z. B. in einem Prozess genutzt werden der eine deutsche und englische Version eines Antragsformulars hat.