### PR TITLE
Fix CaseWorkerGetter not outputing the correct name

### DIFF
--- a/scripts/commons/serviceportal/CaseWorkerGetter.groovy
+++ b/scripts/commons/serviceportal/CaseWorkerGetter.groovy
@@ -66,7 +66,7 @@ class CaseWorkerGetter {
       } else {
         logMessage += "  Ausprägung is ok.\n"
       }
-      assignedCaseworkerName = assignedOrgUnit.oe.i18n.find { it.sprache == "de" }
+      assignedCaseworkerName = assignedOrgUnit.oe.i18n.find { it.sprache == "de" }.name
       // Find relevant "Kommunikation"
       logMessage += "  Checking \"Kommunikation\" of orgUnit...\n"
       Set<ProcessOrganisationseinheitKommunikationV1> kommunikationsWithServicekonto = assignedOrgUnit.oe.kommunikation.findAll { it?.kanal == "SERVICEKONTO" }


### PR DESCRIPTION
It was something like `ProcessOrganisationseinheitI18nV1(sprache=de, name=SEITENBAU - OrgUnit für Prozessentwicklung, kurzbeschreibung=null)` (i.e. the String representation of the entire class, rather than only the name itself)