### PR TITLE
Normalize line endings in test resources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/resources/** text eol=lf


### PR DESCRIPTION
Under Windows, the default line break format used is CRLF. This causes errors in the FormDumper tests when they are run locally. Therefore, the line ending format LF is now explicitly specified for the test/resources directory and all its subdirectories using the .gitattributes

If the conversion does not work immediately, the following commands can help to fetch the affected files again:
 git rm --cached -r test/resources/
 git reset --hard