### PR TITLE
Add a parameter to the HTMLDumper for choosing between two header types

### DIFF
--- a/scripts/commons/serviceportal/forms/formdumper/HtmlDumper.groovy
+++ b/scripts/commons/serviceportal/forms/formdumper/HtmlDumper.groovy
@@ -55,6 +55,7 @@ import de.seitenbau.serviceportal.scripting.api.v1.form.content.FormContentV1
  */
 class HtmlDumper extends AbstractFormDumper {
   final int baseHeadingLevel
+  final boolean tableWithRowHeaders
 
   /**
    * Initialize a new HtmlDumper.
@@ -65,10 +66,11 @@ class HtmlDumper extends AbstractFormDumper {
    * @param param baseHeadingLevel the HTML-heading level (i.e. the "2" in "&lt;h2&gt;" used for the headings before each group
    *   instance)
    */
-  HtmlDumper(FormContentV1 formContent, ScriptingApiV1 api, boolean includeMetadata, int baseHeadingLevel = 2) {
+  HtmlDumper(FormContentV1 formContent, ScriptingApiV1 api, boolean includeMetadata, int baseHeadingLevel = 2, boolean tableWithRowHeaders = false) {
     super(formContent, api, includeMetadata)
 
     this.baseHeadingLevel = baseHeadingLevel
+    this.tableWithRowHeaders = tableWithRowHeaders
   }
 
   @Override
@@ -82,7 +84,10 @@ class HtmlDumper extends AbstractFormDumper {
     currentResult += "<h${baseHeadingLevel}>${groupInstance.title}</h${baseHeadingLevel}>"
     // General headings for the instance
     currentResult += "<table class=\"summary-form\">"
-    currentResult += "<thead><tr><th>Feld</th><th>Ihre Eingabe</th></tr></thead>"
+    // Set Column Headers only when tableWithRowHeaders = false
+    if (!tableWithRowHeaders){
+      currentResult += "<thead><tr><th>Feld</th><th>Ihre Eingabe</th></tr></thead>"
+    }
     currentResult += "<tbody>"
     return currentResult
   }
@@ -99,7 +104,12 @@ class HtmlDumper extends AbstractFormDumper {
     currentResult += "<tr>"
 
     // Left column: The question
-    currentResult += "<td>${field.label ?: ""}</td>"
+    // Use <td> or <th> depending on whether they are column headers or row headers
+    if (tableWithRowHeaders) {
+      currentResult += "<th>${field.label ?: ""}</th>"
+    } else {
+      currentResult += "<td>${field.label ?: ""}</td>"
+    }
 
     // Right column: The answer
     currentResult += "<td>"

--- a/test/FormDumperSpecification.groovy
+++ b/test/FormDumperSpecification.groovy
@@ -278,6 +278,20 @@ mainGroupId:0:name,"Testname"
     html == expectedHtml
   }
 
+  def "dumping a form to HTML Table with row headers"() {
+    given:
+    String json = getClass().getResourceAsStream("resources/formContent_allFields.json").text
+    FormContentV1 formContent = JsonToFormContentConverter.convert(json)
+
+    when:
+    HtmlDumper dumper = new HtmlDumper(formContent, mockedApi, false, 2, true)
+    String html = dumper.dump()
+
+    then:
+    def expectedHtml = new File('test/resources/expectedWithRowHeaders.html').text.replaceAll("\n *<", "<")
+    html == expectedHtml
+  }
+
   def "dumping a form to HTML Table vith VerifiedFormFieldValueV1 values"() {
     given:
     FormContentV1 formContent = new FormContentV1("6000357:testform:v1.0")

--- a/test/resources/expectedWithRowHeaders.html
+++ b/test/resources/expectedWithRowHeaders.html
@@ -1,0 +1,62 @@
+<h2>Main Group</h2>
+<table class="summary-form">
+    <tbody>
+    <tr>
+        <th>Time</th>
+        <td>10:44</td>
+    </tr>
+    <tr>
+        <th>Yes/No</th>
+        <td>Ja</td>
+    </tr>
+    <tr>
+        <th>NPA</th>
+        <td>Sie waren NICHT mit dem neuem Personalausweis angemeldet</td>
+    </tr>
+    <tr>
+        <th>Textfield</th>
+        <td>Textfield content with &lt;html&gt;HTML&lt;/html&gt;</td>
+    </tr>
+    <tr>
+        <th>Sinple Checkbox</th>
+        <td>Ja</td>
+    </tr>
+    <tr>
+        <th>Radio Buttons</th>
+        <td>first label</td>
+    </tr>
+    <tr>
+        <th>Textarea</th>
+        <td>Textarea
+content</td>
+    </tr>
+    <tr>
+        <th>Multiselect</th>
+        <td>first label, second label</td>
+    </tr>
+    <tr>
+        <th>Checkbox List</th>
+        <td>first label, second label</td>
+    </tr>
+    <tr>
+        <th>Fileupload</th>
+        <td>Datei: &quot;dummy.pdf&quot;</td>
+    </tr>
+    <tr>
+        <th>Date</th>
+        <td>09.08.2015</td>
+    </tr>
+    <tr>
+        <th>SelectOptions</th>
+        <td>second label</td>
+    </tr>
+    <tr>
+        <th>Eurobetrag</th>
+        <td>5.66 &euro;</td>
+    </tr>
+    <tr>
+        <th>Name</th>
+        <td>Testname</td>
+    </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
Ticket: [SKDE-2308](https://jira.pmp.seitenbau.com/browse/SKDE-2308)

With this feature, you can now choose between column headers and row headers when dumping a form to html. The default behavior (column header) is currently set as the default.